### PR TITLE
refactor: follow logs after restarting container, validate configuration

### DIFF
--- a/src/container.py
+++ b/src/container.py
@@ -80,6 +80,7 @@ class ContainerManagement:
             return
         logging.info("Restarting the docker container : %s", self.postgresql_container.name)
         self.postgresql_container.restart()
+        self._follow_container_logs()
 
     def _recreate_container(self, configuration):
         if self.postgresql_container:

--- a/src/shutdown_component.py
+++ b/src/shutdown_component.py
@@ -31,5 +31,6 @@ def main():
     docker_client = docker.DockerClient(version="auto")
     cleanup_container(docker_client, container_name)
 
+
 if __name__ == "__main__":
     main()

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,3 +1,4 @@
+import pytest
 import src.constants as consts
 from awsiot.greengrasscoreipc.clientv2 import GreengrassCoreIPCClientV2
 from awsiot.greengrasscoreipc.model import GetConfigurationResponse, GetSecretValueResponse, SecretValue
@@ -45,7 +46,7 @@ def test_configuration_set_credential_secret_config(mocker):
 
     secret_value_reponse = GetSecretValueResponse(
         secret_value=SecretValue(
-            secret_string='{"POSTGRES_USER": "this-is-a-username", "POSTGRES_PASSWORD": "this-is-a-password"}'
+            secret_string='{"POSTGRES_USER": "this-is-a-username", "POSTGRES_PASSWORD": "Thi5-is-@-password"}'
         )
     )
     mock_ipc_get_secret = mocker.patch.object(GreengrassCoreIPCClientV2, "get_secret_value", return_value=secret_value_reponse)
@@ -56,9 +57,53 @@ def test_configuration_set_credential_secret_config(mocker):
     assert mock_ipc_get_secret.call_count == 1
 
     assert configuration.get_container_name() == "greengrass_postgresql"
-    assert configuration.get_db_credentials() == ("this-is-a-username", "this-is-a-password")
+    assert configuration.get_db_credentials() == ("this-is-a-username", "Thi5-is-@-password")
     assert configuration.get_host_volume() == consts.DEFAULT_HOST_VOLUME
     assert configuration.get_host_port() == consts.DEFAULT_HOST_PORT
+
+
+def test_configuration_set_credential_missing_credentials(mocker):
+    mocker.patch("awsiot.greengrasscoreipc", return_value=None)
+    ipc_client = GreengrassCoreIPCClientV2()
+    configuration_response = GetConfigurationResponse(value={"DBCredentialSecret": "secret-arn"})
+    mocker.patch.object(GreengrassCoreIPCClientV2, "get_configuration", return_value=configuration_response)
+
+    secret_value_reponse = GetSecretValueResponse(
+        secret_value=SecretValue(
+            secret_string='{"POSTGRES_USERNAME": "this-is-a-username", "POSTGRES_PASSWORD": "Thi5-is-@-password"}'
+        )
+    )
+    mocker.patch.object(GreengrassCoreIPCClientV2, "get_secret_value", return_value=secret_value_reponse)
+    configuration_handler = ComponentConfigurationIPCHandler(ipc_client)
+    with pytest.raises(Exception) as err:
+        configuration_handler.get_configuration()
+    assert (
+        "Missing postgresql credentials. Please provide a valid secret with postgresql username (POSTGRES_USER) and password"
+        " (POSTGRES_PASSWORD) credentials"
+        in err.value.args[0]
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_password",
+    ["!Lessthan16", "!7nouppercasebut16char", "!7NOLOWERCASEBUT16CHAR", "NOdigit!nThepassword", "No5specialCharacter"],
+)
+def test_configuration_set_credential_invalid_password(mocker, invalid_password):
+    mocker.patch("awsiot.greengrasscoreipc", return_value=None)
+    ipc_client = GreengrassCoreIPCClientV2()
+    configuration_response = GetConfigurationResponse(value={"DBCredentialSecret": "secret-arn"})
+    mocker.patch.object(GreengrassCoreIPCClientV2, "get_configuration", return_value=configuration_response)
+    secret_str = '{"POSTGRES_USER": "this-is-a-username", "POSTGRES_PASSWORD": "' + invalid_password + '"}'
+    secret_value_reponse = GetSecretValueResponse(secret_value=SecretValue(secret_string=secret_str))
+    mocker.patch.object(GreengrassCoreIPCClientV2, "get_secret_value", return_value=secret_value_reponse)
+    configuration_handler = ComponentConfigurationIPCHandler(ipc_client)
+    with pytest.raises(Exception) as err:
+        configuration_handler.get_configuration()
+    assert (
+        "Invalid postgresql password. Password must be at least 16 character long with uppercase and lowercase letters,"
+        " numbers, and special characters."
+        in err.value.args[0]
+    )
 
 
 def test_configuration_set_conf_volumes(mocker):

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -152,7 +152,7 @@ def test_container_management_restart_container(mocker):
     )
 
     mocker.patch.object(GreengrassCoreIPCClientV2, "get_configuration", return_value=mock_get_configuration_response)
-
+    mocker.patch("threading.Thread", return_value=None)
     mocker.patch("docker.DockerClient.containers", return_value=ContainerCollection())
     mocker.patch.object(docker.DockerClient.containers, "get", return_value=Container())
     mocker.patch("pathlib.Path.is_file", return_value=True)
@@ -160,9 +160,11 @@ def test_container_management_restart_container(mocker):
     mock_stop_container = mocker.patch.object(Container, "stop", return_value=None)
     mock_run_container = mocker.patch.object(docker.DockerClient.containers, "run", return_value=None)
     mock_restart_container = mocker.patch.object(Container, "restart", return_value=None)
+    mock_logs_container = mocker.patch.object(Container, "logs", return_value=[])
     cm = ContainerManagement(mock_ipc_client, docker.DockerClient, mock_configuration_handler)
     cm.subscribe_to_configuration_updates()
     assert not mock_remove_container.called
     assert not mock_stop_container.called
     assert not mock_run_container.called
     assert mock_restart_container.called
+    assert mock_logs_container.called

--- a/test/test_shutdown_component.py
+++ b/test/test_shutdown_component.py
@@ -34,11 +34,12 @@ def test_remove_container_no_container(mocker):
 def test_shutdown_component_no_container(mocker):
     mocker.patch("awsiot.greengrasscoreipc", return_value=None)
     mocker.patch("src.configuration_handler", return_value=None)
-    mocker.patch("src.shutdown_component", return_value=None)
     mocker.patch("docker.DockerClient", return_value=None)
-    import src.shutdown_component
-
-    mock_cleanup_container = mocker.patch.object(src.shutdown_component, "cleanup_container", return_value=None)
+    mock_remove_container = mocker.patch.object(Container, "remove", return_value=None)
+    mock_stop_container = mocker.patch.object(Container, "stop", return_value=None)
+    mock_cleanup_container = mocker.patch("src.shutdown_component.cleanup_container", return_value=None)
     main()
 
-    assert not mock_cleanup_container.called
+    assert mock_cleanup_container.called
+    assert not mock_remove_container.called
+    assert not mock_stop_container.called


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Validate configuration parameters. 
- follow logs when the container is restarted

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.