### PR TITLE
fix: postgres server command works when no config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: ['3.10']
         config:
           - os: ubuntu-latest
           - os: macos-latest

--- a/src/constants.py
+++ b/src/constants.py
@@ -14,6 +14,7 @@ DEFAULT_CONTAINER_NAME = "greengrass_postgresql"
 DEFAULT_HOST_VOLUME = Path().joinpath("postgresql").resolve()
 DEFAULT_CONTAINER_PORT = "5432/tcp"
 DEFAULT_DB_NAME = "postgres"
+POSTGRES_COMMAND_DO_NOT_CHANGE = "postgres"
 POSTGRES_DB_KEY = "POSTGRES_DB"
 DEFAULT_CONTAINER_VOLUME = "/var/lib/postgresql/data"
 POSTGRES_IMAGE = "postgres:alpine3.16"

--- a/src/container.py
+++ b/src/container.py
@@ -14,6 +14,7 @@ from src.constants import (
     DEFAULT_CONTAINER_PORT,
     DEFAULT_CONTAINER_VOLUME,
     DEFAULT_DB_NAME,
+    POSTGRES_COMMAND_DO_NOT_CHANGE,
     POSTGRES_DB_KEY,
     POSTGRES_IMAGE,
     POSTGRES_PASSWORD_FILE_KEY,
@@ -147,7 +148,7 @@ class ContainerManagement:
 
         self.postgresql_container = self.docker_client.containers.run(
             POSTGRES_IMAGE,
-            "{} {}".format(DEFAULT_DB_NAME, self._create_config_command(config)),
+            "{} {}".format(POSTGRES_COMMAND_DO_NOT_CHANGE, self._create_config_command(config)),
             name=container_name,
             ports=postgres_ports,
             environment=postgres_env,
@@ -174,7 +175,7 @@ class ContainerManagement:
         command = ""
         server_configuration_files = config.get_pg_config_files()
         if not server_configuration_files:
-            return
+            return command
         for conf_file in server_configuration_files.keys():
             command = command + " -c {}={}".format(SUPPORTED_CONFIGURATION_FILES[conf_file], f"{CUSTOM_FILES}/{conf_file}")
         return command


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixes a bug where if no config is provided, then the container will exit due to the initial command failing. 

**Why is this change necessary:**
Bugfix for a common use case.

**How was this change tested:**
Manually tested.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.