### PR TITLE
adding configuration option for postgres image

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The `aws.greengrass.labs.database.PostgreSQL` component supports the following c
     * HostPort: The port of GG core device where the docker container postgresql server port is published. 
       * (`string`)
       * default: `5432`
+    * ContainerImage (_optional_) : The PostgreSQL Docker container image to be deployed. Available images can be found [here](https://hub.docker.com/_/postgres)
+      * (`string`)
+      * default: `postgres:alpine3.16`
     * ContainerName (_optional_) : The name of the Docker container
       * (`string`)
       * default: `greengrass_postgresql`

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -7,12 +7,14 @@ from awsiot.greengrasscoreipc.model import GetConfigurationResponse, GetSecretVa
 
 from src.constants import (
     CONTAINER_MAPPING_KEY,
+    CONTAINER_IMAGE_KEY,
     CONTAINER_NAME_KEY,
     DEFAULT_CONTAINER_NAME,
     DEFAULT_HOST_PORT,
     DEFAULT_HOST_VOLUME,
     HOST_PORT_KEY,
     HOST_VOLUME_KEY,
+    DEFAULT_CONTAINER_IMAGE,
     POSTGRES_PASSWORD_KEY,
     POSTGRES_SERVER_CONFIGURATION_FILES_KEY,
     POSTGRES_USERNAME_KEY,
@@ -29,6 +31,7 @@ class ComponentConfiguration:
         self.__host_volume = DEFAULT_HOST_VOLUME
         self.__host_port = DEFAULT_HOST_PORT
         self.__container_name = DEFAULT_CONTAINER_NAME
+        self.__container_image = DEFAULT_CONTAINER_IMAGE
         self.__db_username = ""
         self.__db_password = ""
         self.__pg_config_files = {}
@@ -57,6 +60,9 @@ class ComponentConfiguration:
             None
         """
         component_config = config_response.value
+
+        print(f"DEBUG: Component config is {component_config}")
+
         if CONTAINER_MAPPING_KEY not in component_config:
             return
         container_config = component_config[CONTAINER_MAPPING_KEY]
@@ -64,6 +70,8 @@ class ComponentConfiguration:
             self.__host_port = container_config[HOST_PORT_KEY]
         if container_config.get(HOST_VOLUME_KEY):
             self.__host_volume = container_config[HOST_VOLUME_KEY]
+        if container_config.get(CONTAINER_IMAGE_KEY):
+            self.__container_image = container_config[CONTAINER_IMAGE_KEY]
         if container_config.get(CONTAINER_NAME_KEY):
             self.__container_name = container_config[CONTAINER_NAME_KEY]
 
@@ -143,6 +151,11 @@ class ComponentConfiguration:
     def get_container_name(self):
         "Returns docker container name"
         return self.__container_name
+
+    def get_container_image(self):
+        "Returns docker container image"
+        print(f"DEBUG: Image is {self.__container_image}")
+        return self.__container_image
 
     def get_host_port(self):
         "Returns docker host port"

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 HOST_PORT_KEY = "HostPort"
 HOST_VOLUME_KEY = "HostVolume"
+CONTAINER_IMAGE_KEY = "ContainerImage"
 CONTAINER_NAME_KEY = "ContainerName"
 CONTAINER_MAPPING_KEY = "ContainerMapping"
 DB_CREDENTIAL_SECRET_KEY = "DBCredentialSecret"
@@ -17,7 +18,7 @@ DEFAULT_DB_NAME = "postgres"
 POSTGRES_COMMAND_DO_NOT_CHANGE = "postgres"
 POSTGRES_DB_KEY = "POSTGRES_DB"
 DEFAULT_CONTAINER_VOLUME = "/var/lib/postgresql/data"
-POSTGRES_IMAGE = "postgres:alpine3.16"
+DEFAULT_CONTAINER_IMAGE = "postgres:alpine3.16"
 POSTGRES_SERVER_CONFIGURATION_FILES_KEY = "ConfigurationFiles"
 SUPPORTED_CONFIGURATION_FILES = {"postgresql.conf": "config_file", "pg_hba.conf": "hba_file", "pg_ident.conf": "ident_file"}
 CUSTOM_FILES = "/custom_files"

--- a/src/container.py
+++ b/src/container.py
@@ -16,7 +16,6 @@ from src.constants import (
     DEFAULT_DB_NAME,
     POSTGRES_COMMAND_DO_NOT_CHANGE,
     POSTGRES_DB_KEY,
-    POSTGRES_IMAGE,
     POSTGRES_PASSWORD_FILE_KEY,
     POSTGRES_USERNAME_FILE_KEY,
     SECRETS_KEY,
@@ -147,7 +146,7 @@ class ContainerManagement:
         logging.info("Running the docker container : %s", container_name)
 
         self.postgresql_container = self.docker_client.containers.run(
-            POSTGRES_IMAGE,
+            config.get_container_image(),
             "{} {}".format(POSTGRES_COMMAND_DO_NOT_CHANGE, self._create_config_command(config)),
             name=container_name,
             ports=postgres_ports,

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -15,13 +15,14 @@ def test_configuration_default_values(mocker):
     assert configuration.get_db_credentials() == ("", "")
     assert configuration.get_host_volume() == consts.DEFAULT_HOST_VOLUME
     assert configuration.get_host_port() == consts.DEFAULT_HOST_PORT
+    assert configuration.get_container_image() == consts.DEFAULT_CONTAINER_IMAGE
 
 
 def test_configuration_set_container_config(mocker):
     mocker.patch("awsiot.greengrasscoreipc", return_value=None)
     ipc_client = GreengrassCoreIPCClientV2()
     configuration_response = GetConfigurationResponse(
-        value={"ContainerMapping": {"HostPort": "8000", "HostVolume": "/some/volume/", "ContainerName": "some-container-name"}}
+        value={"ContainerMapping": {"HostPort": "8000", "HostVolume": "/some/volume/", "ContainerName": "some-container-name", "ContainerImage": "some-image"}}
     )
     mock_ipc_get_config = mocker.patch.object(
         GreengrassCoreIPCClientV2, "get_configuration", return_value=configuration_response
@@ -34,6 +35,7 @@ def test_configuration_set_container_config(mocker):
     assert configuration.get_db_credentials() == ("", "")
     assert configuration.get_host_volume() == "/some/volume/"
     assert configuration.get_host_port() == "8000"
+    assert configuration.get_container_image() == "some-image"
 
 
 def test_configuration_set_credential_secret_config(mocker):

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -12,7 +12,7 @@ from awsiot.greengrasscoreipc.model import (
 from docker.models.containers import Container, ContainerCollection
 from src.configuration import ComponentConfiguration
 from src.configuration_handler import ComponentConfigurationIPCHandler
-from src.constants import POSTGRES_IMAGE, POSTGRES_PASSWORD_FILE_KEY, POSTGRES_USERNAME_FILE_KEY
+from src.constants import POSTGRES_PASSWORD_FILE_KEY, POSTGRES_USERNAME_FILE_KEY
 from src.container import ContainerManagement
 
 
@@ -59,6 +59,7 @@ def test_container_management_create_or_recreate_container(mocker, change_test_d
                 "HostPort": "8000",
                 "HostVolume": "/some/volume/",
                 "ContainerName": "some-container-name",
+                "ContainerImage": "some-image",
                 "DBCredentialSecret": "secret",
             }
         }
@@ -115,6 +116,7 @@ def test_container_management_run_container(mocker, change_test_dir):
                 "HostPort": "8000",
                 "HostVolume": "/some/volume/",
                 "ContainerName": "some-container-name",
+                "ContainerImage": "some-image",
             },
             "DBCredentialSecret": "secret",
             "ConfigurationFiles": {"postgresql.conf": "/path/to/custom/postgresql.conf"},
@@ -142,7 +144,7 @@ def test_container_management_run_container(mocker, change_test_dir):
     assert cm.secrets_path.exists()
     assert cm.secrets_path.joinpath(POSTGRES_PASSWORD_FILE_KEY).is_file()
     assert cm.secrets_path.joinpath(POSTGRES_USERNAME_FILE_KEY).is_file()
-    assert POSTGRES_IMAGE in args[0]
+    assert "some-image" in args[0]
     assert kwargs["name"] == "some-container-name"
     assert kwargs["detach"]
     assert kwargs["environment"] == {
@@ -174,6 +176,7 @@ def test_container_management_no_update_when_same_configuration(mocker):
                 "HostPort": "8000",
                 "HostVolume": "/some/volume/",
                 "ContainerName": "some-container-name",
+                "ContainerImage": "some-image",
                 "DBCredentialSecret": "secret",
             },
             "ConfigurationFiles": {"postgresql.conf": "/path/to/custom/postgresql.conf"},


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds the ability to set the PostgreSQL Docker container image in deployments via a new option `ContainerImage` in the `ContainerMapping` configuration section.

**Why is this change necessary:**

Currently, this component hard-codes the PostgreSQL version. If a user wants to launch a different version of the PostgreSQL container, they must manually edit the value in `constants.py`. While this can be edited, it is inflexible and requires component updates in order to change versions. It also means that all Greengrass devices running the component are locked to the same PostgreSQL versioning.

By allowing this option to be configurable, version changes and configurations can be logically deployed through Greengrass without the need for code updates.

**How was this change tested:**

A component was built from this repository and deployed with PostgreSQL v17 using the updated configuration settings:

![image](https://github.com/user-attachments/assets/3bfe3a5d-4a52-4283-9599-766c36cbfdfa)

Result:

```
[vagrant@air test]$ docker ps
CONTAINER ID   IMAGE                COMMAND                  CREATED          STATUS          PORTS                                       NAMES
9eb54bd13c86   postgres:17-alpine   "docker-entrypoint.s…"   36 minutes ago   Up 36 minutes   0.0.0.0:5432->5432/tcp, :::5432->5432/tcp   greengrass_postgresql
```

Updates to relevant tests in the included Pytest suite have been added to verify the functionality of these changes as well.

**Any additional information or context required to review the change:**

**Checklist:**
- [x] Updated the README if applicable
- [x] Updated or added new unit tests
- [x] Updated or added new integration tests
- [x] Updated or added new end-to-end tests
- [x] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.